### PR TITLE
fixed about nginx balance case, when no valid server, throw errorMsg …

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -162,10 +162,12 @@ class Client
     {
         $response = $this->client->recv();
 
-        if ($response === '') {
+        if ($response === '' || !$this->client->isConnected()) {
             $this->reConnect();
         } elseif ($response === false) {
-            if ($this->client->errCode !== SOCKET_ETIMEDOUT) {
+            if($this->client->errCode === SOCKET_ECONNRESET) {
+                $this->client->close();
+            } else if ($this->client->errCode !== SOCKET_ETIMEDOUT) {
                 throw new RuntimeException($this->client->errMsg, $this->client->errCode);
             }
         } elseif (strlen($response) > 0) {


### PR DESCRIPTION
修复在nginx负载均衡mqtt的代理下，先启动subscribe 进程，这时抛出异常Connection reset by peer，然后再启动后端的代理的server，subscribe 进程这时无法connect to server（已异常甚至退出了），否则这种情况下需要使用者捕获异常处理了