### PR TITLE
对自动重连后订阅事件丢失的优化

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -97,7 +97,7 @@ class Client
             'properties' => $properties,
             'topics' => $topics,
         ];
-     
+
         $this->subscribeData = [$topics, $properties];
 
         return $this->send($data);

--- a/src/Client.php
+++ b/src/Client.php
@@ -40,6 +40,8 @@ class Client
 
     private $clientType;
 
+    protected $subscribeData;
+
     const COROUTINE_CLIENT_TYPE = 1;
 
     const SYNC_CLIENT_TYPE = 2;
@@ -95,6 +97,8 @@ class Client
             'properties' => $properties,
             'topics' => $topics,
         ];
+     
+        $this->subscribeData = [$topics, $properties];
 
         return $this->send($data);
     }
@@ -168,6 +172,8 @@ class Client
             ++$reConnectTime;
         }
         $this->connect((bool) $this->connectData['clean_session'] ?? true, $this->connectData['will'] ?? []);
+
+        $this->subscribeData && $this->subscribe(...$this->subscribeData);
     }
 
     public function send(array $data, bool $response = true)


### PR DESCRIPTION
自动重连时对事件订阅进行重新绑定