### PR TITLE
Fix error in calculating properties length

### DIFF
--- a/src/Property/PackProperty.php
+++ b/src/Property/PackProperty.php
@@ -19,7 +19,6 @@ class PackProperty
 {
     public static function connect(array $data): string
     {
-        $length = 0;
         $tmpBody = '';
         $connect = array_flip(PacketMap::$connect);
         foreach ($data as $key => $item) {
@@ -28,43 +27,34 @@ class PackProperty
                 $tmpBody .= chr($property);
                 switch ($property) {
                     case Property::SESSION_EXPIRY_INTERVAL:
-                        $length += 5;
                         $tmpBody .= PackTool::longInt($item);
                         break;
                     case Property::AUTHENTICATION_METHOD:
                     case Property::AUTHENTICATION_DATA:
-                        $length += 3;
-                        $length += strlen($item);
                         $tmpBody .= PackTool::string($item);
                         break;
                     case Property::REQUEST_PROBLEM_INFORMATION:
                     case Property::REQUEST_RESPONSE_INFORMATION:
-                        $length += 2;
                         $tmpBody .= chr((int) $item);
                         break;
                     case Property::RECEIVE_MAXIMUM:
                     case Property::TOPIC_ALIAS_MAXIMUM:
                     case Property::MAXIMUM_PACKET_SIZE:
-                        $length += 3;
                         $tmpBody .= PackTool::shortInt($item);
                         break;
                 }
             } else {
                 // Property::USER_PROPERTY
-                $length += 5;
-                $length += strlen((string) $key);
-                $length += strlen((string) $item);
                 $tmpBody .= chr($connect['user_property']);
                 $tmpBody .= PackTool::stringPair((string) $key, (string) $item);
             }
         }
 
-        return chr($length) . $tmpBody;
+        return PackTool::genProperties($tmpBody);
     }
 
     public static function willProperties(array $data): string
     {
-        $length = 0;
         $tmpBody = '';
         $willProperties = array_flip(PacketMap::$willProperties);
         foreach ($data as $key => $item) {
@@ -74,37 +64,29 @@ class PackProperty
                 switch ($property) {
                     case Property::MESSAGE_EXPIRY_INTERVAL:
                     case Property::WILL_DELAY_INTERVAL:
-                        $length += 5;
                         $tmpBody .= PackTool::longInt($item);
                         break;
                     case Property::CONTENT_TYPE:
                     case Property::RESPONSE_TOPIC:
                     case Property::CORRELATION_DATA:
-                        $length += 3;
-                        $length += strlen($item);
                         $tmpBody .= PackTool::string($item);
                         break;
                     case Property::PAYLOAD_FORMAT_INDICATOR:
-                        $length += 2;
                         $tmpBody .= chr((int) $item);
                         break;
                 }
             } else {
                 // Property::USER_PROPERTY
-                $length += 5;
-                $length += strlen((string) $key);
-                $length += strlen((string) $item);
                 $tmpBody .= chr($willProperties['user_property']);
                 $tmpBody .= PackTool::stringPair((string) $key, (string) $item);
             }
         }
 
-        return chr($length) . $tmpBody;
+        return PackTool::genProperties($tmpBody);
     }
 
     public static function connAck(array $data): string
     {
-        $length = 0;
         $tmpBody = '';
         $connAck = array_flip(PacketMap::$connAck);
         foreach ($data as $key => $item) {
@@ -114,13 +96,11 @@ class PackProperty
                 switch ($property) {
                     case Property::SESSION_EXPIRY_INTERVAL:
                     case Property::MAXIMUM_PACKET_SIZE:
-                        $length += 5;
                         $tmpBody .= PackTool::longInt($item);
                         break;
                     case Property::SERVER_KEEP_ALIVE:
                     case Property::RECEIVE_MAXIMUM:
                     case Property::TOPIC_ALIAS_MAXIMUM:
-                        $length += 3;
                         $tmpBody .= PackTool::shortInt($item);
                         break;
                     case Property::ASSIGNED_CLIENT_IDENTIFIER:
@@ -129,8 +109,6 @@ class PackProperty
                     case Property::RESPONSE_INFORMATION:
                     case Property::SERVER_REFERENCE:
                     case Property::REASON_STRING:
-                        $length += 3;
-                        $length += strlen($item);
                         $tmpBody .= PackTool::string($item);
                         break;
                     case Property::MAXIMUM_QOS:
@@ -138,26 +116,21 @@ class PackProperty
                     case Property::WILDCARD_SUBSCRIPTION_AVAILABLE:
                     case Property::SUBSCRIPTION_IDENTIFIER_AVAILABLE:
                     case Property::SHARED_SUBSCRIPTION_AVAILABLE:
-                        $length += 2;
                         $tmpBody .= chr((int) $item);
                         break;
                 }
             } else {
                 // Property::USER_PROPERTY
-                $length += 5;
-                $length += strlen((string) $key);
-                $length += strlen((string) $item);
                 $tmpBody .= chr($connAck['user_property']);
                 $tmpBody .= PackTool::stringPair((string) $key, (string) $item);
             }
         }
 
-        return chr($length) . $tmpBody;
+        return PackTool::genProperties($tmpBody);
     }
 
     public static function publish(array $data): string
     {
-        $length = 0;
         $tmpBody = '';
         $publish = array_flip(PacketMap::$publish);
         foreach ($data as $key => $item) {
@@ -166,47 +139,36 @@ class PackProperty
                 $tmpBody .= chr($property);
                 switch ($property) {
                     case Property::MESSAGE_EXPIRY_INTERVAL:
-                        $length += 5;
                         $tmpBody .= PackTool::longInt($item);
                         break;
                     case Property::TOPIC_ALIAS:
-                        $length += 3;
                         $tmpBody .= PackTool::shortInt($item);
                         break;
                     case Property::CONTENT_TYPE:
                     case Property::RESPONSE_TOPIC:
                     case Property::CORRELATION_DATA:
-                        $length += 3;
-                        $length += strlen($item);
                         $tmpBody .= PackTool::string($item);
                         break;
                     case Property::PAYLOAD_FORMAT_INDICATOR:
-                        $length += 2;
                         $tmpBody .= chr((int) $item);
                         break;
                     case Property::SUBSCRIPTION_IDENTIFIER:
-                        $length += 1;
                         $value = PackTool::varInt((int) $item);
-                        $length += strlen($value);
                         $tmpBody .= $value;
                         break;
                 }
             } else {
                 // Property::USER_PROPERTY
-                $length += 5;
-                $length += strlen((string) $key);
-                $length += strlen((string) $item);
                 $tmpBody .= chr($publish['user_property']);
                 $tmpBody .= PackTool::stringPair((string) $key, (string) $item);
             }
         }
 
-        return chr($length) . $tmpBody;
+        return PackTool::genProperties($tmpBody);
     }
 
     public static function pubAndSub(array $data): string
     {
-        $length = 0;
         $tmpBody = '';
         $pubAndSub = array_flip(PacketMap::$pubAndSub);
         foreach ($data as $key => $item) {
@@ -215,27 +177,21 @@ class PackProperty
                 $tmpBody .= chr($property);
                 switch ($property) {
                     case Property::REASON_STRING:
-                        $length += 3;
-                        $length += strlen($item);
                         $tmpBody .= PackTool::string($item);
                         break;
                 }
             } else {
                 // Property::USER_PROPERTY
-                $length += 5;
-                $length += strlen((string) $key);
-                $length += strlen((string) $item);
                 $tmpBody .= chr($pubAndSub['user_property']);
                 $tmpBody .= PackTool::stringPair((string) $key, (string) $item);
             }
         }
 
-        return chr($length) . $tmpBody;
+        return PackTool::genProperties($tmpBody);
     }
 
     public static function subscribe(array $data): string
     {
-        $length = 0;
         $tmpBody = '';
         $subscribe = array_flip(PacketMap::$subscribe);
         foreach ($data as $key => $item) {
@@ -244,45 +200,36 @@ class PackProperty
                 $tmpBody .= chr($property);
                 switch ($property) {
                     case Property::SUBSCRIPTION_IDENTIFIER:
-                        $length += 1;
                         $value = PackTool::varInt((int) $item);
-                        $length += strlen($value);
                         $tmpBody .= $value;
                         break;
                 }
             } else {
                 // Property::USER_PROPERTY
-                $length += 5;
-                $length += strlen((string) $key);
-                $length += strlen((string) $item);
                 $tmpBody .= chr($subscribe['user_property']);
                 $tmpBody .= PackTool::stringPair((string) $key, (string) $item);
             }
         }
 
-        return chr($length) . $tmpBody;
+        return PackTool::genProperties($tmpBody);
     }
 
     public static function unSubscribe(array $data): string
     {
-        $length = 0;
         $tmpBody = '';
         $unSubscribe = array_flip(PacketMap::$unSubscribe);
         foreach ($data as $key => $item) {
             // Property::USER_PROPERTY
-            $length += 5;
-            $length += strlen((string) $key);
-            $length += strlen((string) $item);
+
             $tmpBody .= chr($unSubscribe['user_property']);
             $tmpBody .= PackTool::stringPair((string) $key, (string) $item);
         }
 
-        return chr($length) . $tmpBody;
+        return PackTool::genProperties($tmpBody);
     }
 
     public static function disConnect(array $data): string
     {
-        $length = 0;
         $tmpBody = '';
         $disConnect = array_flip(PacketMap::$disConnect);
         foreach ($data as $key => $item) {
@@ -291,32 +238,25 @@ class PackProperty
                 $tmpBody .= chr($property);
                 switch ($property) {
                     case Property::SESSION_EXPIRY_INTERVAL:
-                        $length += 5;
                         $tmpBody .= PackTool::longInt($item);
                         break;
                     case Property::SERVER_REFERENCE:
                     case Property::REASON_STRING:
-                        $length += 3;
-                        $length += strlen($item);
                         $tmpBody .= PackTool::string($item);
                         break;
                 }
             } else {
                 // Property::USER_PROPERTY
-                $length += 5;
-                $length += strlen((string) $key);
-                $length += strlen((string) $item);
                 $tmpBody .= chr($disConnect['user_property']);
                 $tmpBody .= PackTool::stringPair((string) $key, (string) $item);
             }
         }
 
-        return chr($length) . $tmpBody;
+        return PackTool::genProperties($tmpBody);
     }
 
     public static function auth(array $data): string
     {
-        $length = 0;
         $tmpBody = '';
         $auth = array_flip(PacketMap::$auth);
         foreach ($data as $key => $item) {
@@ -327,21 +267,16 @@ class PackProperty
                     case Property::AUTHENTICATION_METHOD:
                     case Property::AUTHENTICATION_DATA:
                     case Property::REASON_STRING:
-                        $length += 3;
-                        $length += strlen($item);
                         $tmpBody .= PackTool::string($item);
                         break;
                 }
             } else {
                 // Property::USER_PROPERTY
-                $length += 5;
-                $length += strlen((string) $key);
-                $length += strlen((string) $item);
                 $tmpBody .= chr($auth['user_property']);
                 $tmpBody .= PackTool::stringPair((string) $key, (string) $item);
             }
         }
 
-        return chr($length) . $tmpBody;
+        return PackTool::genProperties($tmpBody);
     }
 }

--- a/src/Property/PackProperty.php
+++ b/src/Property/PackProperty.php
@@ -153,8 +153,7 @@ class PackProperty
                         $tmpBody .= chr((int) $item);
                         break;
                     case Property::SUBSCRIPTION_IDENTIFIER:
-                        $value = PackTool::varInt((int) $item);
-                        $tmpBody .= $value;
+                        $tmpBody .= PackTool::varInt((int) $item);
                         break;
                 }
             } else {

--- a/src/Property/PackProperty.php
+++ b/src/Property/PackProperty.php
@@ -200,8 +200,7 @@ class PackProperty
                 $tmpBody .= chr($property);
                 switch ($property) {
                     case Property::SUBSCRIPTION_IDENTIFIER:
-                        $value = PackTool::varInt((int) $item);
-                        $tmpBody .= $value;
+                        $tmpBody .= PackTool::varInt((int) $item);
                         break;
                 }
             } else {
@@ -220,7 +219,6 @@ class PackProperty
         $unSubscribe = array_flip(PacketMap::$unSubscribe);
         foreach ($data as $key => $item) {
             // Property::USER_PROPERTY
-
             $tmpBody .= chr($unSubscribe['user_property']);
             $tmpBody .= PackTool::stringPair((string) $key, (string) $item);
         }

--- a/src/Tools/PackTool.php
+++ b/src/Tools/PackTool.php
@@ -57,6 +57,11 @@ class PackTool extends Common
         return chr($type) . static::packRemainingLength($bodyLength);
     }
 
+    public static function genProperties(string $body): string
+    {
+        return static::packRemainingLength(strlen($body)) . $body;
+    }
+
     protected static function packRemainingLength(int $bodyLength): string
     {
         $string = '';


### PR DESCRIPTION
Fix #79

The Property Length is encoded as a Variable Byte Integer.
see https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901028