### PR TITLE
fix: Creation of dynamic property is deprecated

### DIFF
--- a/src/Message/AbstractMessage.php
+++ b/src/Message/AbstractMessage.php
@@ -26,8 +26,8 @@ abstract class AbstractMessage
             $methodName = 'set' . ucfirst($k);
             if (method_exists($this, $methodName)) {
                 $this->{$methodName}($v);
-            } else {
-                $this->{$k} = $v;
+            } elseif(isset($this->$k)) {
+                $this->{$k} = $v;    
             }
         }
     }

--- a/src/Message/AbstractMessage.php
+++ b/src/Message/AbstractMessage.php
@@ -26,8 +26,8 @@ abstract class AbstractMessage
             $methodName = 'set' . ucfirst($k);
             if (method_exists($this, $methodName)) {
                 $this->{$methodName}($v);
-            } elseif(isset($this->$k)) {
-                $this->{$k} = $v;    
+            } elseif (isset($this->{$k})) {
+                $this->{$k} = $v;
             }
         }
     }


### PR DESCRIPTION
当设置不存在的属性时会有警告，因为不是继承了 \stdClass ，所以只能加个 isset 来判断属性是否存在。

[WARNING] ErrorException: Creation of dynamic property Simps\MQTT\Message\PubAck::$dup is deprecated